### PR TITLE
Fixed ambiguous redirects

### DIFF
--- a/travis-encrypt
+++ b/travis-encrypt
@@ -3,7 +3,7 @@
 if [[ $# < 2 ]]; then
     p="$(basename $0)"
     here=$(mktemp)
-    git remote -v 2>/dev/null | grep -oP '(?<=github.com[:/])([^/]+/[^/]+?)(?=\.git| )' > "${here}"
+    git remote -v 2>/dev/null | grep -oP '(?<=github.com[:/])([^/]+/[^/]+?)(?=\.git| )' > "$here"
     IFS=/ read user repo < "$here"
 else
     user="$1"

--- a/travis-encrypt
+++ b/travis-encrypt
@@ -3,8 +3,8 @@
 if [[ $# < 2 ]]; then
     p="$(basename $0)"
     here=$(mktemp)
-    git remote -v 2>/dev/null | grep -oP '(?<=github.com[:/])([^/]+/[^/]+?)(?=\.git| )' > $here
-    IFS=/ read user repo < $here
+    git remote -v 2>/dev/null | grep -oP '(?<=github.com[:/])([^/]+/[^/]+?)(?=\.git| )' > "${here}"
+    IFS=/ read user repo < "$here"
 else
     user="$1"
     repo="$2"


### PR DESCRIPTION
Was getting errors like this:
```bash
travis-encrypt: line 7: $here: ambiguous redirect
```

My `bash` version:
```bash
bash --version
GNU bash, version 4.1.2(2)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

Quoting the variables that are targets of the redirects seem to fix it. 

Great tool BTW. Insanely frustrating to do otherwise. Thanks.