### PR TITLE
Sketch Travis API authentication

### DIFF
--- a/travis-encrypt
+++ b/travis-encrypt
@@ -24,9 +24,10 @@ value="$1"
 
 # Fetch key
 keyurl="https://api.travis-ci.org/repos/$user/$repo/key"
+authheader="\"Authorization: token <TRAVIS_API_TOKEN>"
 echo "Fetching key from $keyurl ..." >&2
 keyfile=$(mktemp)
-curl -s "$keyurl" > "$keyfile" || {
+curl -s "$keyurl" -H "$authheader" > "$keyfile" || {
     echo "Couldn't fetch key from $keyurl!" >&2
     exit 1
 }


### PR DESCRIPTION
Hey there, really helpful script. Alas, it seems TravisCI now requires authentication. It was necessary to pass an API token like I sketch here - perhaps you care to include it? 

One thing, the TravisCI API token available through https://travis-ci.org/account/preferences doesn't appear to be stable. It could only be valid per login session, but I'm unsure.